### PR TITLE
Fix installation instruction to use 'get' instead of 'install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Problem Details for HTTP APIs.
 Install using [go install](https://go.dev/ref/mod#go-install):
 
 ``` sh
-go install github.com/neocotic/go-problem
+go get github.com/neocotic/go-problem
 ```
 
 Then import the package into your own code:


### PR DESCRIPTION
Install is for binaries, not libraries.