### PR TITLE
Release 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - '1.21.x'
-          - '1.22.x'
+          - '1.24.x'
+          - '1.25.x'
 
     steps:
       - name: Checkout

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,12 @@
+## Version 0.2.0, 2025.09.30
+
+* Bump support for Go to 1.24+
+* Change all functions that return `Builder` to return `*Builder` pointer instead
+* Add built-in support for [zap](https://github.com/uber-go/zap) logging
+* Fix issue causing `Translator` to be ignored when specified
+* Improve documentation
+* Bump all dependencies to latest versions
+
+## Version 0.1.0, 2024.05.13
+
+* Initial release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,9 @@ $ make format
 $ make test
 ```
 
-You must have at least [Golang](https://go.dev) version 1.21 or newer installed.
+You must have at least [Golang](https://go.dev) version 1.24 or newer installed.
 
 All pull requests should be made to the `main` branch.
 
-Don't forget to add your details to the list of
-[AUTHORS.md](https://github.com/neocotic/go-problem/blob/main/AUTHORS.md) if you want your contribution to be recognized
-by others.
+Remember to add your details to the list of [AUTHORS.md](https://github.com/neocotic/go-problem/blob/main/AUTHORS.md) if
+you want your contribution to be recognized by others.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (C) 2024 neocotic
+Copyright (C) 2025 neocotic
 
 Permission is hereby granted, free of charge, to any person obtaining a copy  
 of this software and associated documentation files (the "Software"), to deal  

--- a/README.md
+++ b/README.md
@@ -87,6 +87,6 @@ A list of contributors can be found in [AUTHORS.md](https://github.com/neocotic/
 
 ## License
 
-Copyright © 2024 neocotic
+Copyright © 2025 neocotic
 
 See [LICENSE.md](https://github.com/neocotic/go-problem/raw/main/LICENSE.md) for more information on our MIT license.

--- a/builder.go
+++ b/builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/code.go
+++ b/code.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,6 +19,8 @@
 // SOFTWARE.
 
 package problem
+
+// TODO: Consider moving "code" etc out to separate library and recommend use via extension as not part of RFC
 
 import (
 	"errors"

--- a/context.go
+++ b/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/definition.go
+++ b/definition.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/generator.go
+++ b/generator.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -85,7 +85,7 @@ type Generator struct {
 	//		switch {
 	//		case defType.Status == 0:
 	//			return defType.LogLevel
-	//		case def.Type.Status > 500:
+	//		case defType.Status > 500:
 	//			return LogLevelError
 	//		default:
 	//			return LogLevelWarn
@@ -106,9 +106,9 @@ type Generator struct {
 	// StackFlag provides control over the capturing of a stack trace and its visibility on a Problem.
 	//
 	// StackFlag is the default Flag. If Builder.Stack or WithStack are used, but no flags are provided, this is
-	// considered equal to passing FlagField and FlagLog. This would mean that the UUID will be generated and the fully
-	// visible on the Problem both in terms of field and within the logs. If FlagDisable is ever passed, all other flags
-	// are ignored and the stack trace is not captured (or inherited) and will not be visible on the Problem.
+	// considered equal to passing FlagField and FlagLog. This would mean that the stack trace will be generated and the
+	// fully visible on the Problem both in terms of field and within the logs. If FlagDisable is ever passed, all other
+	// flags are ignored and the stack trace is not captured (or inherited) and will not be visible on the Problem.
 	//
 	// For example;
 	//
@@ -165,8 +165,7 @@ type Generator struct {
 	//
 	//	g := &Generator{Unwrapper: FullUnwrapper()}
 	Unwrapper Unwrapper
-	// UUIDFlag provides control over the generation of an Universally Unique Identifier and its visibility on a
-	// Problem.
+	// UUIDFlag provides control over the generation of a Universally Unique Identifier and its visibility on a Problem.
 	//
 	// UUIDFlag is the default Flag. If Builder.UUID or WithUUID are used, but no flags are provided, this is considered
 	// equal to passing FlagField and FlagLog. This would mean that the UUID will be generated and the fully visible on

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,17 @@
 module github.com/neocotic/go-problem
 
-go 1.21
+go 1.24
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/neocotic/go-optional v0.1.2
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.11.1
+	go.uber.org/zap v1.27.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.uber.org/multierr v1.10.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,12 @@ github.com/neocotic/go-pointers v0.2.0 h1:WL3y72qVNeixePF6of6ACtz/JlvQXzoMC0Z3UL
 github.com/neocotic/go-pointers v0.2.0/go.mod h1:IQiaywMJpATTcUPA/mY2HwjgLajUYRTUxmdKu/fJTS8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
-go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/http.go
+++ b/http.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/http/definition.go
+++ b/http/definition.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,8 +21,9 @@
 package http
 
 import (
-	"github.com/neocotic/go-problem"
 	"net/http"
+
+	"github.com/neocotic/go-problem"
 )
 
 var (

--- a/http/doc.go
+++ b/http/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/http/type.go
+++ b/http/type.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -343,7 +343,7 @@ var (
 	// UnsupportedMediaType is a built-in reusable problem.Type that may be used to represent an HTTP Unsupported Media
 	// Type error.
 	UnsupportedMediaType = problem.Type{
-		LogLevel: problem.LogLevelWarn,
+		LogLevel: problem.LogLevelDebug,
 		Status:   http.StatusUnsupportedMediaType,
 		Title:    http.StatusText(http.StatusUnsupportedMediaType),
 		TitleKey: "problem.http.UnsupportedMediaType.title",

--- a/i18n.go
+++ b/i18n.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 // Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 // Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 // Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -25,9 +25,10 @@
 package stack
 
 import (
-	"github.com/neocotic/go-problem/internal/buffer"
 	"runtime"
 	"sync"
+
+	"github.com/neocotic/go-problem/internal/buffer"
 )
 
 // Stack is a captured stack trace.

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 // Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/log.go
+++ b/log.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/option.go
+++ b/option.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/problem.go
+++ b/problem.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/type.go
+++ b/type.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -85,7 +85,7 @@ const (
 	// ContentTypeJSONUTF8 is the recommended content/media type to represent a problem in JSON format with UTF-8
 	// encoding.
 	ContentTypeJSONUTF8 = ContentTypeJSON + "; charset=utf-8"
-	// ContentTypeXML is the recommended content/media type to represent a Problem in XML format.
+	// ContentTypeXML is the recommended content/media type to represent a problem in XML format.
 	ContentTypeXML = "application/problem+xml"
 	// ContentTypeXMLUTF8 is the recommended content/media type to represent a problem in XML format with UTF-8
 	// encoding.

--- a/unwrap.go
+++ b/unwrap.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2025 neocotic
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package problem
+
+// Unwrapper is a function used by Builder.Wrap and Wrap to handle an already wrapped Problem in err's tree.
+//
+// An Unwrapper is effectively responsible for deciding what, if any, information from a wrapped Problem is to be used
+// to construct the new Problem. Any such information will not take precedence over any explicitly defined Problem
+// fields, however, it will take precedence over any information derived from a Definition or its Type.
+type Unwrapper func(err error) Problem
+
+// FullUnwrapper returns an Unwrapper that extracts all fields from a wrapped Problem in err's tree, if present. These
+// fields will not take precedence over any explicitly defined Problem fields, however, it will take precedence over any
+// fields derived from a Definition or its Type.
+func FullUnwrapper() Unwrapper {
+	return unwrapAllFields
+}
+
+// NoopUnwrapper returns an Unwrapper that does nothing.
+func NoopUnwrapper() Unwrapper {
+	return func(_ error) Problem {
+		return Problem{}
+	}
+}
+
+// PropagatedFieldUnwrapper returns an Unwrapper that extracts only fields that are expected to be propagated (e.g.
+// captured stack trace, generated "UUID") from a wrapped Problem in err's tree, if present. Any such fields will not
+// take precedence over any explicitly defined Problem fields, however, it will take precedence over any fields derived
+// from a Definition or its Type.
+func PropagatedFieldUnwrapper() Unwrapper {
+	return unwrapPropagatedFields
+}
+
+// unwrapAllFields extracts all fields from a wrapped Problem in err's tree, if present. These fields will not take
+// precedence over any explicitly defined Problem fields, however, it will take precedence over any fields derived from
+// a Definition or its Type.
+func unwrapAllFields(err error) Problem {
+	if p, isProblem := As(err); isProblem && p != nil {
+		return *p
+	}
+	return Problem{}
+}
+
+// unwrapPropagatedFields extracts only fields that are expected to be propagated (e.g. captured stack trace, generated
+// "UUID") from a wrapped Problem in err's tree, if present. Any such fields will not take precedence over any
+// explicitly defined Problem fields, however, it will take precedence over any fields derived from a Definition or its
+// Type.
+func unwrapPropagatedFields(err error) Problem {
+	if p, isProblem := As(err); isProblem && p != nil {
+		return Problem{
+			Stack:   p.Stack,
+			UUID:    p.UUID,
+			logInfo: p.logInfo,
+		}
+	}
+	return Problem{}
+}

--- a/uri/builder.go
+++ b/uri/builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,6 +20,8 @@
 
 // Package uri provides support for constructing URI references to be used within problems.
 package uri
+
+// TODO: Consider moving "uri" etc out to separate library as not part of RFC
 
 import (
 	"fmt"

--- a/uuid.go
+++ b/uuid.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 neocotic
+// Copyright (C) 2025 neocotic
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,6 +19,8 @@
 // SOFTWARE.
 
 package problem
+
+// TODO: Consider moving "uuid" etc out to separate library and recommend use via extension as not part of RFC (likely needs "plugin" support)
 
 import (
 	"context"


### PR DESCRIPTION
* Bump support for Go to 1.24+
* Change all functions that return `Builder` to return `*Builder` pointer instead
* Add built-in support for [zap](https://github.com/uber-go/zap) logging
* Fix issue causing `Translator` to be ignored when specified
* Improve documentation
* Bump all dependencies to latest versions